### PR TITLE
Add support for cached mapping loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "xyz.rodit.snapmod"
         minSdk 24
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -34,7 +34,7 @@ dependencies {
 
     implementation files('libs/snapmod.jar')
     implementation 'androidx.preference:preference:1.2.0'
-    implementation 'xyz.rodit:xposed:1.2.1'
+    implementation 'xyz.rodit:xposed:1.3.0'
 
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/xyz/rodit/snapmod/Shared.java
+++ b/app/src/main/java/xyz/rodit/snapmod/Shared.java
@@ -11,8 +11,8 @@ public class Shared {
 
     public static final String SNAPMOD_FORCE_RESUME_ACTIVITY = SNAPMOD_PACKAGE_NAME + ".ForceResumeActivity";
 
-    public static final String CONTEXT_HOOK_CLASS = "com.snap.mushroom.MainActivity";
-    public static final String CONTEXT_HOOK_METHOD = "onCreate";
+    public static final String CONTEXT_HOOK_CLASS = "android.app.Application";
+    public static final String CONTEXT_HOOK_METHOD = "attach";
 
     public static final String SNAPMOD_MEDIA_PREFIX = "SnapMod_";
 


### PR DESCRIPTION
Bump version of xyz.rodit.xposed library to 1.3.0 and move hooks around to support cached mapping loading. Methods are now hooked as soon as `android.app.Application#attach` is called if cached mappings are available for the current version of Snapchat. If not, the module waits for the service to send the mappings then loads the hooks and caches the mappings for the next launch.